### PR TITLE
Linter config file

### DIFF
--- a/es/02-javascript/02-practica/start-here/.eslintrc.json
+++ b/es/02-javascript/02-practica/start-here/.eslintrc.json
@@ -1,0 +1,14 @@
+{
+    "env": {
+        "node": true
+    },
+    "extends": "eslint:recommended",
+    "rules": {
+        "quotes": [
+            "error",
+            "single"
+        ],
+        "max-len": ["error", 100],
+        "max-statements": ["error", 40]
+    }
+}


### PR DESCRIPTION
In node 6.4.0 unzipping start-here.zip and doing npm test generates a linter error, related to a react jsx plugin.
This file avoid this error while mantaining linter configs specified in document.